### PR TITLE
fix(repairs): Bugfixes and improvements

### DIFF
--- a/repairs/api.py
+++ b/repairs/api.py
@@ -32,6 +32,7 @@ def make_sales_order(source_name, target_doc=None):
 	def set_missing_values(source, target):
 		target.naming_series = frappe.db.get_single_value("Repair Settings", "order_naming_series")
 		target.order_type = "Maintenance"
+		target.authorize_production = True
 
 	def set_item_details(source, target, source_parent):
 		target.uom = frappe.db.get_value("Item", source.item_code, "stock_uom")

--- a/repairs/public/js/warranty_claim.js
+++ b/repairs/public/js/warranty_claim.js
@@ -1,6 +1,16 @@
 frappe.ui.form.on("Warranty Claim", {
 	setup: (frm) => {
 		frm.set_query('shipping_address', erpnext.queries.address_query);
+
+		// triggers add fetch, sets value in model and runs triggers
+		// ref to `trigger_link_fields` in form.js
+		if (!frm.doc.address_display || !frm.doc.service_address) {
+			$.each(frm.fields_dict, function (fieldname, field) {
+				if (field.df.fieldtype == "Link" && frm.doc[fieldname]) {
+					field.set_value(frm.doc[fieldname]);
+				}
+			});
+		}
 	},
 
 	refresh: (frm) => {
@@ -92,12 +102,10 @@ frappe.ui.form.on("Warranty Claim", {
 						{ fieldname: "sb_socket", fieldtype: "Section Break" },
 						{ label: __("LEFT SOCKET"), fieldname: "cb_left_socket", fieldtype: "Column Break" },
 						{ label: __("Broken"), fieldname: "left_broken_socket", fieldtype: "Check" },
-						{ label: __("Swap"), fieldname: "left_swap_socket", fieldtype: "Check" },
 						{ label: __("Worn Out"), fieldname: "left_worn_out_socket", fieldtype: "Check" },
 						{ label: __("Spinning / Loose"), fieldname: "left_loose_socket", fieldtype: "Check" },
 						{ label: __("RIGHT SOCKET"), fieldname: "cb_right_socket", fieldtype: "Column Break" },
 						{ label: __("Broken"), fieldname: "right_broken_socket", fieldtype: "Check" },
-						{ label: __("Swap"), fieldname: "right_swap_socket", fieldtype: "Check" },
 						{ label: __("Worn Out"), fieldname: "right_worn_out_socket", fieldtype: "Check" },
 						{ label: __("Spinning / Loose"), fieldname: "right_loose_socket", fieldtype: "Check" },
 


### PR DESCRIPTION
- Auto-authorize service orders for production
  - As requested by JHA
- Run link triggers for addresses in Service Request
  - The reason for doing this is because the Requests are created directly into the database, so the JS events that toggle the address display field don't run, so users have no way to refer to the actual address, just it's name.
- Remove 'Swap' option during item testing
  - As requested by JHA