### PR TITLE
fix(selling): Unauthorize service orders for production by default

### DIFF
--- a/repairs/api.py
+++ b/repairs/api.py
@@ -32,7 +32,6 @@ def make_sales_order(source_name, target_doc=None):
 	def set_missing_values(source, target):
 		target.naming_series = frappe.db.get_single_value("Repair Settings", "order_naming_series")
 		target.order_type = "Maintenance"
-		target.authorize_production = True
 
 	def set_item_details(source, target, source_parent):
 		target.uom = frappe.db.get_value("Item", source.item_code, "stock_uom")


### PR DESCRIPTION
From Jessie:

> SVC-O-00008 was just invoiced and paid via PayPal, this SVC was automatically approved for production. We need the setup of SVC-O to be the same as the SO when it comes to this.  We (Shelley and I) will manually approval ALL PayPal transactions as they come in once we verify that we actually received the funds.