### PR TITLE
fix: Override customer's default ship address with selected address in service request

### DIFF
--- a/repairs/api.py
+++ b/repairs/api.py
@@ -32,6 +32,7 @@ def make_sales_order(source_name, target_doc=None):
 	def set_missing_values(source, target):
 		target.naming_series = frappe.db.get_single_value("Repair Settings", "order_naming_series")
 		target.order_type = "Maintenance"
+		target.set_onload("shipping_address_name", source.shipping_address)
 
 	def set_item_details(source, target, source_parent):
 		target.serial_no = source_parent.unlinked_serial_no or source_parent.serial_no

--- a/repairs/public/js/sales_order.js
+++ b/repairs/public/js/sales_order.js
@@ -18,18 +18,25 @@ frappe.ui.form.on("Sales Order", {
 			.map(item => item.warranty_claim)
 			.filter(claim => claim)
 
-		if (frm.is_new() && warranty_claims.length > 0) {
-			frappe.call({
-				method: "repairs.api.get_customer_claim_count",
-				args: {
-					customer: frm.doc.customer
-				},
-				callback: (r) => {
-					if (r.message.count > 1) {
-						frm.trigger("get_service_items");
+		if (frm.is_new()) {
+			if (frm.doc.__onload.shipping_address_name) {
+				frm.set_value("shipping_address_name", frm.doc.__onload.shipping_address_name);
+				erpnext.utils.get_address_display(frm, "shipping_address_name", "shipping_address", false);
+			}
+
+			if (warranty_claims.length > 0) {
+				frappe.call({
+					method: "repairs.api.get_customer_claim_count",
+					args: {
+						customer: frm.doc.customer
+					},
+					callback: (r) => {
+						if (r.message.count > 1) {
+							frm.trigger("get_service_items");
+						}
 					}
-				}
-			});
+				});
+			}
 		}
 	},
 


### PR DESCRIPTION
**Problem:**

If a Service Request has a customer's preferred shipping address, any Sales Orders made from it would use the customer's default shipping address, rather than the preferred one.