### PR TITLE
fix: don't copy testing details into service order

### DIFF
--- a/repairs/api.py
+++ b/repairs/api.py
@@ -58,12 +58,9 @@ def make_sales_order(source_name, target_doc=None):
 		elif source.ear_side == "Both":
 			target.qty = 2
 
-	field_map = {"testing_details": "instructions"}
-
 	return make_mapped_doc("Sales Order", source_name, target_doc,
-		target_cdt="Sales Order Item", field_map=field_map,
-		postprocess=set_missing_values, child_postprocess=set_item_details,
-		check_for_existing=False)
+		target_cdt="Sales Order Item", postprocess=set_missing_values,
+		child_postprocess=set_item_details, check_for_existing=False)
 
 
 @frappe.whitelist()


### PR DESCRIPTION
JHA doesn't want the results of testing to move to the Service Order, which is also showing up on the print and being sent to the customer. They want to add separate comments in the order before it goes out.