### PR TITLE
fix: move dashboard additions from ERPNext to custom app

### DIFF
--- a/repairs/hooks.py
+++ b/repairs/hooks.py
@@ -164,3 +164,7 @@ doc_events = {
 # override_whitelisted_methods = {
 # 	"frappe.desk.doctype.event.event.get_events": "repairs.event.get_events"
 # }
+
+override_doctype_dashboards = {
+	"Warranty Claim": "repairs.utils.get_wc_dashboard_data"
+}

--- a/repairs/utils.py
+++ b/repairs/utils.py
@@ -271,3 +271,32 @@ def make_mapped_doc(target_dt, source_dn, target_doc, target_cdt=None, filters=N
 			frappe.throw(_("A {0} document already exists for this request.".format(target_dt)))
 
 	return get_mapped_doc("Warranty Claim", source_dn, table_map, target_doc, postprocess=postprocess)
+
+
+def get_wc_dashboard_data(data):
+	if not data:
+		return frappe._dict({
+			'fieldname': 'warranty_claim',
+			'non_standard_fieldnames': {},
+			'internal_links': {},
+			'transactions': [
+				{
+					'label': _('Reference'),
+					'items': ['Quotation', 'Sales Order']
+				},
+				{
+					'label': _('Stock'),
+					'items': ['Stock Entry']
+				},
+				{
+					'label': _('Work'),
+					'items': ['Work Order']
+				},
+				{
+					'label': _('Fulfilment'),
+					'items': ['Sales Invoice', 'Delivery Note']
+				}
+			]
+		})
+
+	return data


### PR DESCRIPTION
**Refs:**
- https://github.com/DigiThinkIT/erpnext/commit/91497c6340a1269bb6e64c942fc6c7209a09ea2d
- https://github.com/DigiThinkIT/erpnext/commit/697d1610f2d5031bbde97afab935104d8923d550

We can't move this to ERPNext since all the logic for the doctypes is in this app.