### PR TITLE
fix: set IEM owner bug from frontend

### DIFF
--- a/repairs/utils.py
+++ b/repairs/utils.py
@@ -58,7 +58,7 @@ def validate_serial_no_warranty(serial_no, method):
 
 
 def set_iem_owner(warranty_claim, method):
-	if warranty_claim.item_code and warranty_claim.item_group != "Custom":
+	if warranty_claim.item_group and warranty_claim.item_group != "Custom":
 		warranty_claim.iem_owner = None
 		return
 


### PR DESCRIPTION
Requires https://github.com/DigiThinkIT/jhaudio_customizations/pull/1232.

<hr>

From Jordan:

> When customers make a claim and fill out the “Old Serial Number” field on the website on the front end, the system won’t populate with subsequent IEM owner on the form.