### PR TITLE
fix: setup.py requirements

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,19 +1,17 @@
 # -*- coding: utf-8 -*-
-from setuptools import setup, find_packages
-try: # for pip >= 10
-    from pip._internal.req import parse_requirements
-except ImportError: # for pip <= 9.0.3
-    from pip.req import parse_requirements
-import re, ast
+import ast
+import re
+
+from setuptools import find_packages, setup
 
 # get version from __version__ variable in repairs/__init__.py
 _version_re = re.compile(r'__version__\s+=\s+(.*)')
 
 with open('repairs/__init__.py', 'rb') as f:
-    version = str(ast.literal_eval(_version_re.search(
-        f.read().decode('utf-8')).group(1)))
+	version = str(ast.literal_eval(_version_re.search(f.read().decode('utf-8')).group(1)))
 
-requirements = parse_requirements("requirements.txt", session="")
+with open('requirements.txt') as f:
+	install_requires = f.read().strip().split('\n')
 
 setup(
 	name='repairs',
@@ -24,6 +22,5 @@ setup(
 	packages=find_packages(),
 	zip_safe=False,
 	include_package_data=True,
-	install_requires=[str(ir.req) for ir in requirements],
-	dependency_links=[str(ir._link) for ir in requirements if ir._link]
+	install_requires=install_requires
 )


### PR DESCRIPTION
```
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/home/rohan/jhb/apps/repairs/setup.py", line 27, in <module>
        install_requires=[str(ir.req) for ir in requirements],
  File "/home/rohan/jhb/apps/repairs/setup.py", line 27, in <listcomp>
        install_requires=[str(ir.req) for ir in requirements],
AttributeError: 'ParsedRequirement' object has no attribute 'req'
```