### PR TITLE
fix: fetching of item name on basis of item code

### DIFF
--- a/repairs/api.py
+++ b/repairs/api.py
@@ -93,9 +93,11 @@ def make_sales_order(source_name, target_doc=None):
 		elif source.ear_side == "Both":
 			target.qty = 2
 
-	return make_mapped_doc("Sales Order", source_name, target_doc,
+	sales_order_doc = make_mapped_doc("Sales Order", source_name, target_doc,
 		target_cdt="Sales Order Item", postprocess=set_missing_values,
 		child_postprocess=set_item_details, check_for_existing=False)
+	sales_order_doc.run_method("set_missing_values")
+	return sales_order_doc
 
 
 @frappe.whitelist()


### PR DESCRIPTION
While doing Get items from > Service Request, in Sales Order it was not fetching item name in child table.

**Before**
![service_request_before](https://user-images.githubusercontent.com/53251406/139912796-c6119ab3-12cf-425c-84f7-da05cabd92e6.gif)


**After**
![service_request_after](https://user-images.githubusercontent.com/53251406/139912867-8a9b6875-c115-4b7f-9024-71abd934c4d8.gif)


