### PR TITLE
fix: creation of sales order from service request

### DIFF
--- a/repairs/public/js/warranty_claim.js
+++ b/repairs/public/js/warranty_claim.js
@@ -1,5 +1,11 @@
 frappe.ui.form.on("Warranty Claim", {
 	setup: (frm) => {
+		frm.make_methods = {
+			'Sales Order': () => frappe.model.open_mapped_doc({
+				method: "repairs.api.make_sales_order",
+				frm: frm
+			})
+		};
 		frm.set_query('shipping_address', erpnext.queries.address_query);
 
 		// triggers add fetch, sets value in model and runs triggers


### PR DESCRIPTION
While creation Sales Order from Service Request it was not populating data on sales order page
![so_from_service_rrequest](https://user-images.githubusercontent.com/53251406/139923832-26c86d2d-1690-4175-ada8-8885e67d14ab.gif)

